### PR TITLE
Rebalancer query protection

### DIFF
--- a/packages/fork-tests/tests/20221114-beefy-rebalanced-linear-pool/test/test.fork.ts
+++ b/packages/fork-tests/tests/20221114-beefy-rebalanced-linear-pool/test/test.fork.ts
@@ -1,11 +1,13 @@
 import hre from 'hardhat';
 import { expect } from 'chai';
 import { Contract } from 'ethers';
-
-import { setCode } from '@nomicfoundation/hardhat-network-helpers';
 import * as expectEvent from '@orbcollective/shared-dependencies/expectEvent';
 import { bn, fp, FP_ONE } from '@orbcollective/shared-dependencies/numbers';
-import { MAX_UINT256 } from '@orbcollective/shared-dependencies';
+import { setCode } from '@nomicfoundation/hardhat-network-helpers';
+import { 
+  MAX_UINT256, 
+  getExternalPackageArtifact, 
+  getExternalPackageDeployedAt } from '@orbcollective/shared-dependencies';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import { impersonate, getForkedNetwork, Task, TaskMode, getSigners } from '../../../src';
@@ -302,5 +304,35 @@ describeForkTest('BeefyLinearPoolFactory', 'optimism', 38313066, function () {
   describe('rebalance repeatedly', () => {
     itRebalancesThePool(LinearPoolState.BALANCED);
     itRebalancesThePool(LinearPoolState.BALANCED);
+  });
+
+  describe('rebalancer query protection', async () => {
+    it('reverts with a malicious lending pool', async () => {
+      const { cash } = await vault.getPoolTokenInfo(poolId, USDC);
+      const scaledCash = cash.mul(USDC_SCALING);
+      const { lowerTarget } = await pool.getTargets();
+
+      const exitAmount = scaledCash.sub(lowerTarget.div(3)).div(USDC_SCALING);
+
+      await vault.connect(holder).swap(
+        {
+          kind: SwapKind.GivenOut,
+          poolId,
+          assetIn: pool.address,
+          assetOut: USDC,
+          amount: exitAmount,
+          userData: '0x',
+        },
+        { sender: holder.address, recipient: holder.address, fromInternalBalance: false, toInternalBalance: false },
+        MAX_UINT256,
+        MAX_UINT256
+      );
+
+      await setCode(mooAaveUSDC, getExternalPackageArtifact('linear-pools/MockBeefyVault').deployedBytecode);
+      const mockLendingPool = await getExternalPackageDeployedAt('linear-pools/MockBeefyVault', mooAaveUSDC);
+
+      await mockLendingPool.setRevertType(2); // Type 2 is malicious swap query revert
+      await expect(rebalancer.rebalance(other.address)).to.be.revertedWith('BAL#357'); // MALICIOUS_QUERY_REVERT
+    });
   });
 });

--- a/packages/fork-tests/tests/20221114-beefy-rebalanced-linear-pool/test/test.fork.ts
+++ b/packages/fork-tests/tests/20221114-beefy-rebalanced-linear-pool/test/test.fork.ts
@@ -105,7 +105,6 @@ describeForkTest('BeefyLinearPoolFactory', 'optimism', 38313066, function () {
       if (fees > 0) {
         // The recipient of the rebalance call should get the fees that were collected (though there's some rounding
         // error in the main-wrapped conversion).
-        console.log(finalRecipientMainBalance.sub(initialRecipientMainBalance));
         expect(finalRecipientMainBalance.sub(initialRecipientMainBalance)).to.be.almostEqual(
           fees.div(USDC_SCALING),
           0.0001

--- a/packages/fork-tests/tests/20230102-gearbox-rebalanced-linear-pool/test/test.fork.ts
+++ b/packages/fork-tests/tests/20230102-gearbox-rebalanced-linear-pool/test/test.fork.ts
@@ -4,7 +4,10 @@ import { Contract } from 'ethers';
 import { setCode } from '@nomicfoundation/hardhat-network-helpers';
 import * as expectEvent from '@orbcollective/shared-dependencies/expectEvent';
 import { bn, fp, FP_ONE } from '@orbcollective/shared-dependencies/numbers';
-import { MAX_UINT256 } from '@orbcollective/shared-dependencies';
+import { 
+  MAX_UINT256, 
+  getExternalPackageArtifact, 
+  getExternalPackageDeployedAt } from '@orbcollective/shared-dependencies';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import { impersonate, getForkedNetwork, Task, TaskMode, getSigners } from '../../../src';
@@ -29,6 +32,8 @@ describeForkTest('GearboxLinearPoolFactory', 'mainnet', 15989794, function () {
   const USDC_SCALING = bn(1e12); // USDC has 6 decimals, so its scaling factor is 1e12
 
   const USDC_HOLDER = '0xdfd5293d8e347dfe59e90efd55b2956a1343963d';
+
+  const GEARBOX_VAULT = '0x86130bDD69143D8a4E5fc50bf4323D48049E98E4';
 
   const SWAP_FEE_PERCENTAGE = fp(0.01); // 1%
 
@@ -304,33 +309,33 @@ describeForkTest('GearboxLinearPoolFactory', 'mainnet', 15989794, function () {
     itRebalancesThePool(LinearPoolState.BALANCED);
   });
 
-  // describe('rebalancer query protection', async () => {
-  //   it('reverts with a malicious lending pool', async () => {
-  //     const { cash } = await vault.getPoolTokenInfo(poolId, USDC);
-  //     const scaledCash = cash.mul(USDC_SCALING);
-  //     const { lowerTarget } = await pool.getTargets();
-  //
-  //     const exitAmount = scaledCash.sub(lowerTarget.div(3)).div(USDC_SCALING);
-  //
-  //     await vault.connect(holder).swap(
-  //       {
-  //         kind: SwapKind.GivenOut,
-  //         poolId,
-  //         assetIn: pool.address,
-  //         assetOut: USDC,
-  //         amount: exitAmount,
-  //         userData: '0x',
-  //       },
-  //       { sender: holder.address, recipient: holder.address, fromInternalBalance: false, toInternalBalance: false },
-  //       MAX_UINT256,
-  //       MAX_UINT256
-  //     );
-  //
-  //     await setCode(USDC_LENDING_POOL, getArtifact('v2-pool-linear/MockGearboxLendingPool').deployedBytecode);
-  //     const mockLendingPool = await deployedAt('v2-pool-linear/MockGearboxLendingPool', USDC_LENDING_POOL);
-  //
-  //     await mockLendingPool.setRevertType(2); // Type 2 is malicious swap query revert
-  //     await expect(rebalancer.rebalance(other.address)).to.be.revertedWith('BAL#357'); // MALICIOUS_QUERY_REVERT
-  //   });
-  // });
+  describe('rebalancer query protection', async () => {
+    it('reverts with a malicious lending pool', async () => {
+      const { cash } = await vault.getPoolTokenInfo(poolId, USDC);
+      const scaledCash = cash.mul(USDC_SCALING);
+      const { lowerTarget } = await pool.getTargets();
+
+      const exitAmount = scaledCash.sub(lowerTarget.div(3)).div(USDC_SCALING);
+
+      await vault.connect(holder).swap(
+        {
+          kind: SwapKind.GivenOut,
+          poolId,
+          assetIn: pool.address,
+          assetOut: USDC,
+          amount: exitAmount,
+          userData: '0x',
+        },
+        { sender: holder.address, recipient: holder.address, fromInternalBalance: false, toInternalBalance: false },
+        MAX_UINT256,
+        MAX_UINT256
+      );
+
+      await setCode(GEARBOX_VAULT, getExternalPackageArtifact('linear-pools/MockGearboxVault').deployedBytecode);
+      const mockLendingPool = await getExternalPackageDeployedAt('linear-pools/MockGearboxVault', GEARBOX_VAULT);
+
+      await mockLendingPool.setRevertType(2); // Type 2 is malicious swap query revert
+      await expect(rebalancer.rebalance(other.address)).to.be.revertedWith('BAL#357'); // MALICIOUS_QUERY_REVERT
+    });
+  });
 });


### PR DESCRIPTION
All linear pools outside of this branch have rebalancer query protection already implemented in their respective branches (Silo, Reaper, & Buttonwood).